### PR TITLE
Avoid using `String.replaceAll` API to have better compatibility for node 12 and 14

### DIFF
--- a/ydict.js
+++ b/ydict.js
@@ -35,7 +35,7 @@ var parseAudio = function (data) {
     var re = /https:\\\/\\\/s\.yimg\.com\\\/bg\\\/dict\\\/dreye\\\/live\\\/f\\\/([a-z]+)\.mp3/;
     var found = data.match(re);
     if (!found) return null;
-    return found[0].replaceAll("\\", "");
+    return found[0].replace(/\\/g, '');
 };
 
 var parse = function (data) {


### PR DESCRIPTION
It reports `found[0].replaceAll` is not a function, so I suggest to use `String.replace` API to have better compatibility for Node LTS version (`12` and `14`).

```shell
$ node ydict.js wonderland
/Users/foobar/Projects/ydict.js/ydict.js:38
    return found[0].replaceAll("\\", "");
                    ^

TypeError: found[0].replaceAll is not a function
    at parseAudio (/Users/foobar/Projects/ydict.js/ydict.js:38:21)
```

```shell
$ node
Welcome to Node.js v14.15.3.
Type ".help" for more information.
> 'foo'.replaceAll
undefined
```

```shell
$ node
Welcome to Node.js v12.18.1.
Type ".help" for more information.
> 'foo'.replaceAll
undefined
```